### PR TITLE
Unstake analytics mobile responsive

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -32,11 +32,11 @@
 </svelte:head>
 
 <header class="mt-4">
-  <div class="flex justify-between mx-auto py-4 px-10">
+  <div class="flex justify-center gap-3 md:gap-0 md:justify-between mx-auto py-4 px-10">
     <a href="/">
       <img src="/unstake-name.svg" class="h-12 xs:h-14" alt="Unstake.fi Logo" />
     </a>
-    <nav class="flex gap-1 xs:gap-3 items-center text-sm xs:text-base">
+    <nav class="flex gap-2 md:gap-3 items-center text-sm xs:text-base">
       <a href="/analytics" class:active={path === "/analytics"}>Analytics</a>
       <a href="/provide" class:active={path === "/provide"}>Provide</a>
       <a href="/" class:active={path === "/"}>Unstake</a>

--- a/src/routes/analytics/+page.svelte
+++ b/src/routes/analytics/+page.svelte
@@ -58,9 +58,9 @@
   <div
     class="flex flex-col w-full items-center justify-center align-center gap-4 mt-4"
   >
-    <div class="flex gap-4 w-full">
+    <div class="flex flex-col md:flex-row items-center md:items-start gap-4 w-full">
       <DateBarChartWrapper
-        class="basis-1/2"
+        class="md:basis-1/2 w-full"
         data={selectedDataset}
         dataMap={(d) => ({
           x: d.startTime,
@@ -73,7 +73,7 @@
         graphColor="gray"
       />
       <DateBarChartWrapper
-        class="basis-1/2"
+        class="md:basis-1/2 w-full"
         data={selectedDataset}
         dataMap={(d) => ({
           x: d.endTime,
@@ -90,8 +90,8 @@
     </div>
   </div>
 
-  <div class="flex flex-row gap-4 mt-4">
-    <div class="flex flex-col basis-1/2 rounded-lg bg-stone-800 max-h-72 px-2">
+  <div class="flex flex-col md:flex-row items-center gap-4 mt-4">
+    <div class="flex flex-col w-full md:basis-1/2 rounded-lg bg-stone-800 max-h-96 px-2">
       <div class=" bg-stone-800 py-2">
         <p class="text-md text-stone-400">Completed Unstakings</p>
         <p class="text-lg bold font-semibold">
@@ -168,7 +168,7 @@
         </table>
       </div>
     </div>
-    <div class="flex flex-col basis-1/2 rounded-lg bg-stone-800 max-h-72 px-2">
+    <div class="flex flex-col w-full md:basis-1/2 rounded-lg bg-stone-800 max-h-96 px-2">
       <div class="sticky top-0 bg-stone-800 py-2">
         <p class="text-md text-stone-400">Started Unstakings</p>
         <p class="text-lg bold font-semibold">


### PR DESCRIPTION
Make unstake analytics mobile responsive.

<img width="370" alt="Screenshot 2024-07-02 at 10 59 15 PM" src="https://github.com/EntropicLabs/unstake-ui/assets/21179174/dcd49e09-a321-4fdd-905b-896108011a7f">
